### PR TITLE
Add fast version of Base.dataids for LArray

### DIFF
--- a/src/larray.jl
+++ b/src/larray.jl
@@ -112,6 +112,11 @@ function Base.similar(bc::Broadcast.Broadcasted{LAStyle{T,N,L}}, ::Type{ElType})
     end
 end
 
+# Broadcasting checks for aliasing with Base.dataids but the fallback
+# for AbstractArrays is very slow. Instead, we just call dataids on the
+# wrapped buffer
+Base.dataids(A::LArray) = Base.dataids(A.__x)
+
 """
     @LArray Eltype Size Names
     @LArray Values Names

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -44,6 +44,7 @@ using LabelledArrays, Test, InteractiveUtils
     z = x .+ ones(Float64, 3)
     @test z isa LArray && eltype(z) === Float64
     @test eltype(x .+ 1.) === Float64
+    @test Base.dataids(vals) == Base.dataids(x)
 
     type = Float64 
     dims = (2,2) 


### PR DESCRIPTION
The fallback for AbstractArrays calls `objectid` which will hash the complete object and that can be much more expensive than the `dataids(::Array)` which simply uses the pointer value.