### PR TITLE
Error upon `getproperty` for nonexistent property

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LabelledArrays"
 uuid = "2ee39098-c373-598a-b85f-a56591580800"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.6.3"
+version = "1.6.4"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"

--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -9,7 +9,9 @@ include("larray.jl")
 @generated function __getindex(x::Union{LArray,SLArray},::Val{s}) where s
     syms = symnames(x)
     idx = syms isa NamedTuple ? syms[s] : findfirst(y->y==s,syms)
-    if idx isa Tuple
+    if idx === nothing
+        :(error("type $(typeof(x)) has no field $(s)"))
+    elseif idx isa Tuple
         :(Base.@_propagate_inbounds_meta; view(getfield(x,:__x), $idx...))
     else
         :(Base.@_propagate_inbounds_meta; @views getfield(x,:__x)[$idx])

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -66,7 +66,9 @@ using LabelledArrays, Test, InteractiveUtils
     x = @LArray [1,2,3] (:a,:b,:c)
     y = @LArray [4,5,6] (:d,:e,:f)
     @test LabelledArrays.symnames(typeof(vcat(x,y))) == (:a,:b,:c,:d,:e,:f)
-    @test vcat(x,y) == [1,2,3,4,5,6]  
+    @test vcat(x,y) == [1,2,3,4,5,6]
+
+    @test_throws ErrorException x.z
 end
 
 @testset "Alternate array backends" begin

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -14,6 +14,7 @@ using Test, InteractiveUtils
     @test b[2] == b.b
     @test b[3] == b.c
 
+    @test_throws ErrorException b.d
     @test_throws UndefVarError fill!(a,1)
     @test typeof(b.__x) == SVector{3,Int}
 


### PR DESCRIPTION
Currently accessing a property that does not exist results in a `view` called on `nothing` since `idx` in the following snippet
https://github.com/SciML/LabelledArrays.jl/blob/10779c55925f426b3b91667611ee4f7156f0f059/src/LabelledArrays.jl#L9-L17
will be `nothing`. 

This can be quite confusing to debug, so I added a error with the same message as you'd get if you try to access a non-existent property of a struct, i.e. now you get:

```julia
julia> x = @LArray [1.0,2.0,3.0] (:a, :b, :c)
3-element LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}:
 :a => 1.0
 :b => 2.0
 :c => 3.0

julia> x.d
ERROR: type LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)} has no field d
[...]
```

rather than

```julia
julia> x = @LArray [1.0,2.0,3.0] (:a, :b, :c)
3-element LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}:
 :a => 1.0
 :b => 2.0
 :c => 3.0

julia> x.d
ERROR: ArgumentError: invalid index: nothing of type Nothing
Stacktrace:
  [1] to_index(i::Nothing)
    @ Base ./indices.jl:300
[...]
```

which is the current behavior.

EDIT: Should the error say "has no property" rather than "has no field"?