### PR TITLE
Adds `ChainRulesCore.rrule` for constructors and `getproperty`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,20 +5,23 @@ version = "1.6.6"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 ArrayInterface = "2.8, 3.0"
+ChainRulesCore = "1"
 MacroTools = "0.5"
 StaticArrays = "0.10, 0.11, 0.12, 1.0"
 julia = "1"
 
 [extras]
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "OrdinaryDiffEq", "InteractiveUtils"]
+test = ["Test", "OrdinaryDiffEq", "InteractiveUtils", "ChainRulesTestUtils"]

--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -4,6 +4,7 @@ using LinearAlgebra, StaticArrays, ArrayInterface
 
 include("slarray.jl")
 include("larray.jl")
+include("chainrules.jl")
 
 # Common
 @generated function __getindex(x::Union{LArray,SLArray},::Val{s}) where s

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -1,0 +1,30 @@
+using ChainRulesCore: ChainRulesCore
+
+function ChainRulesCore.rrule(::typeof(getproperty), A::Union{SLArray,LArray}, s::Symbol)
+    function getproperty_LArray_adjoint(d)
+        # Hopefully this reference to `A` is optimized away.
+        Δ = similar(A) .= 0
+        setproperty!(Δ, s, ChainRulesCore.unthunk(d))
+        return (ChainRulesCore.NoTangent(), Δ, ChainRulesCore.NoTangent())
+    end
+    return getproperty(A, s), getproperty_LArray_adjoint
+end
+
+function ChainRulesCore.rrule(::Type{LArray{S}}, x::AbstractArray) where {S}
+    # This rule covers constructors of the form `LArray{(:a, :b)}(x)`
+    # which, amongst other places, is also used in the `@LArray` macro.
+    LArray_adjoint(Δlx::LArray) = ChainRulesCore.NoTangent(), Δlx.__x
+    # Sometimes we're pulling back gradients which are not `LArray`.
+    LArray_adjoint(Δx) = ChainRulesCore.NoTangent(), Δx
+    return LArray{S}(x), LArray_adjoint
+end
+
+# TODO: Can this ruled be combined into the above definition?
+function ChainRulesCore.rrule(::Type{SLArray{Size,S}}, x::AbstractArray) where {Size,S}
+    # This rule covers constructors of the form `LArray{(:a, :b)}(x)`
+    # which, amongst other places, is also used in the `@LArray` macro.
+    SLArray_adjoint(Δlx::SLArray) = ChainRulesCore.NoTangent(), Δlx.__x
+    # Sometimes we're pulling back gradients which are not `LArray`.
+    SLArray_adjoint(Δx) = ChainRulesCore.NoTangent(), Δx
+    return SLArray{Size,S}(x), SLArray_adjoint
+end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -13,18 +13,30 @@ end
 function ChainRulesCore.rrule(::Type{LArray{S}}, x::AbstractArray) where {S}
     # This rule covers constructors of the form `LArray{(:a, :b)}(x)`
     # which, amongst other places, is also used in the `@LArray` macro.
-    LArray_adjoint(Δlx::LArray) = ChainRulesCore.NoTangent(), Δlx.__x
-    # Sometimes we're pulling back gradients which are not `LArray`.
-    LArray_adjoint(Δx) = ChainRulesCore.NoTangent(), Δx
+    function LArray_adjoint(Δx_)
+        Δx = ChainRulesCore.unthunk(Δx_)
+        # Sometimes we're pulling back gradients which are not `LArray`.
+        return if Δ isa LArray
+            ChainRulesCore.NoTangent(), Δx.__x
+        else
+            ChainRulesCore.NoTangent(), Δx
+        end
+    end
     return LArray{S}(x), LArray_adjoint
 end
 
 # TODO: Can this ruled be combined into the above definition?
 function ChainRulesCore.rrule(::Type{SLArray{Size,S}}, x::AbstractArray) where {Size,S}
-    # This rule covers constructors of the form `LArray{(:a, :b)}(x)`
+    # This rule covers constructors of the form `SLArray{(2, ), (:a, :b)}(x)`
     # which, amongst other places, is also used in the `@LArray` macro.
-    SLArray_adjoint(Δlx::SLArray) = ChainRulesCore.NoTangent(), Δlx.__x
-    # Sometimes we're pulling back gradients which are not `LArray`.
-    SLArray_adjoint(Δx) = ChainRulesCore.NoTangent(), Δx
+    function SLArray_adjoint(Δx_)
+        Δx = ChainRulesCore.unthunk(Δx_)
+        # Sometimes we're pulling back gradients which are not `LArray`.
+        return if Δ isa SLArray
+            ChainRulesCore.NoTangent(), Δx.__x
+        else
+            ChainRulesCore.NoTangent(), Δx
+        end
+    end
     return SLArray{Size,S}(x), SLArray_adjoint
 end

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -16,7 +16,7 @@ function ChainRulesCore.rrule(::Type{LArray{S}}, x::AbstractArray) where {S}
     function LArray_adjoint(Δx_)
         Δx = ChainRulesCore.unthunk(Δx_)
         # Sometimes we're pulling back gradients which are not `LArray`.
-        return if Δ isa LArray
+        return if Δx isa LArray
             ChainRulesCore.NoTangent(), Δx.__x
         else
             ChainRulesCore.NoTangent(), Δx
@@ -32,7 +32,7 @@ function ChainRulesCore.rrule(::Type{SLArray{Size,S}}, x::AbstractArray) where {
     function SLArray_adjoint(Δx_)
         Δx = ChainRulesCore.unthunk(Δx_)
         # Sometimes we're pulling back gradients which are not `LArray`.
-        return if Δ isa SLArray
+        return if Δx isa SLArray
             ChainRulesCore.NoTangent(), Δx.__x
         else
             ChainRulesCore.NoTangent(), Δx

--- a/src/chainrules.jl
+++ b/src/chainrules.jl
@@ -25,7 +25,6 @@ function ChainRulesCore.rrule(::Type{LArray{S}}, x::AbstractArray) where {S}
     return LArray{S}(x), LArray_adjoint
 end
 
-# TODO: Can this ruled be combined into the above definition?
 function ChainRulesCore.rrule(::Type{SLArray{Size,S}}, x::AbstractArray) where {Size,S}
     # This rule covers constructors of the form `SLArray{(2, ), (:a, :b)}(x)`
     # which, amongst other places, is also used in the `@LArray` macro.

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,0 +1,18 @@
+@begin "Vector" begin
+    x = randn(2)
+    syms = (:a, :b)
+
+    # Constructors
+    test_rrule(LArray{syms}, x)
+    constructor = @SLArray (2, ) syms
+    test_rrule(constructor, x)
+
+    # `getproperty`
+    lx = LArray{syms}(x)
+    test_rrule(getproperty, lx, first(syms))
+    test_rrule(getproperty, lx, last(syms))
+
+    slx = constructor(x)
+    test_rrule(getproperty, slx, first(syms))
+    test_rrule(getproperty, slx, last(syms))
+end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -1,4 +1,4 @@
-@begin "Vector" begin
+@testset "Vector" begin
     x = randn(2)
     syms = (:a, :b)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,11 @@ using LabelledArrays
 using Test
 using StaticArrays
 using InteractiveUtils
+using ChainRulesTestUtils
 
 @time begin
 @time @testset "SLArrays" begin include("slarrays.jl") end
 @time @testset "LArrays" begin include("larrays.jl") end
 @time @testset "DiffEq" begin include("diffeq.jl") end
+@time @testset "ChainRules" begin include("chainrules.jl") end
 end


### PR DESCRIPTION
This PR adds AD rules for:
- `LArray{syms}`
- `SLArray{size,syms}`
- `getproperty`

This all the issues in https://github.com/SciML/LabelledArrays.jl/issues/91 with the exception of the ForwardDiff.jl-issue for `SLArray`.

Some things of note/questions to address:
- [ ] Are there more constructors we need to add implementations for? There are quite a few constructors, but it's a bit unclear which we need custom rules for atm. For example it might be nice to have rules defined for `LVector(::NamedTuple)`, which currently does not work.