### PR TITLE
Fix and properly test elsize

### DIFF
--- a/src/larray.jl
+++ b/src/larray.jl
@@ -270,5 +270,5 @@ function Base.vcat(x::LArray, y::LArray)
     LArray{(LabelledArrays.symnames(typeof(x))...,LabelledArrays.symnames(typeof(y))...)}(vcat(x.__x,y.__x))
 end
 
-Base.elsize(::Type{<:LArray{T}}) where {T} = T
+Base.elsize(::Type{<:LArray{T}}) where {T} = sizeof(T)
 

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -4,7 +4,7 @@ using LabelledArrays, Test, InteractiveUtils
     vals = [1.0,2.0,3.0]
     syms = (:a,:b,:c)
     x = @LArray vals syms
-    @test Base.elszie(x) == 8
+    @test Base.elsize(x) == Base.elsize(vals) == 8
     @test_nowarn display(x)
     y = @LVector Float64 (:a,:b,:c)
     y .= [1,2,3.]

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -4,6 +4,7 @@ using LabelledArrays, Test, InteractiveUtils
     vals = [1.0,2.0,3.0]
     syms = (:a,:b,:c)
     x = @LArray vals syms
+    @test Base.elszie(x) == 8
     @test_nowarn display(x)
     y = @LVector Float64 (:a,:b,:c)
     y .= [1,2,3.]


### PR DESCRIPTION
I noticed this when you asked if I meant `eltype`.
Not sure what I was thinking with that last PR/about the `gemv` test not getting it.

I'll need to rerun Pumas tests with this.
Anyway, now I'm at least comparing with `elsize` on a `Float64`.