### PR TITLE
Removes allocations with get_tmp that occur in some cases 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,13 @@
 name = "LabelledArrays"
 uuid = "2ee39098-c373-598a-b85f-a56591580800"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.11.1"
+version = "1.11.2"
 
 [deps]
 ArrayInterfaceCore = "30b0a656-2188-435a-8636-2ec0e6a096e2"
 ArrayInterfaceStaticArrays = "b0d46f97-bff5-4637-a19a-dd75974142cd"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
@@ -17,6 +18,7 @@ RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 ArrayInterfaceCore = "0.1.13"
 ArrayInterfaceStaticArrays = "0.1"
 ChainRulesCore = "1"
+ForwardDiff = "0.10.3"
 MacroTools = "0.5"
 PreallocationTools = "0.4"
 RecursiveArrayTools = "2"

--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -65,7 +65,8 @@ end
 ArrayInterfaceCore.can_setindex(::Type{<:SLArray}) = false
 
 function PreallocationTools.get_tmp(dc::PreallocationTools.DiffCache,
-                                    u::LArray{T, N, D, Syms}) where {T <: ForwardDiff.Dual, N, D, Syms}
+                                    u::LArray{T, N, D, Syms}) where {T <: ForwardDiff.Dual,
+                                                                     N, D, Syms}
     nelem = div(sizeof(T), sizeof(eltype(dc.dual_du))) * length(dc.du)
     if nelem > length(dc.dual_du)
         PreallocationTools.enlargedualcache!(dc, nelem)

--- a/src/LabelledArrays.jl
+++ b/src/LabelledArrays.jl
@@ -1,7 +1,7 @@
 module LabelledArrays
 
 using LinearAlgebra, StaticArrays, ArrayInterfaceCore
-import RecursiveArrayTools, PreallocationTools
+import RecursiveArrayTools, PreallocationTools, ForwardDiff
 
 include("slarray.jl")
 include("larray.jl")
@@ -65,7 +65,7 @@ end
 ArrayInterfaceCore.can_setindex(::Type{<:SLArray}) = false
 
 function PreallocationTools.get_tmp(dc::PreallocationTools.DiffCache,
-                                    u::LArray{T, N, D, Syms}) where {T, N, D, Syms}
+                                    u::LArray{T, N, D, Syms}) where {T <: ForwardDiff.Dual, N, D, Syms}
     nelem = div(sizeof(T), sizeof(eltype(dc.dual_du))) * length(dc.du)
     if nelem > length(dc.dual_du)
         PreallocationTools.enlargedualcache!(dc, nelem)


### PR DESCRIPTION
Specifically when `get_tmp(cache::PreallocationTools.DiffCache, u:LArray{T, ...}` where T is _not_ a ForwardDiff.Dual, the method defined for Duals is used (which uses ArrayInterfaceCore.restructure --> allocations, even though we should just get the normal cache back, not the dual cache).

The changes introduced dispatch the present `get_tmp` only on Duals, so that for T <: Number the fallback method for u::AbstractArray in PreallocationTools is used (https://github.com/SciML/PreallocationTools.jl/blob/addfd170cb69f98778f7e5f40a3d9ab352c99b10/src/PreallocationTools.jl#L61)