### PR TITLE
chore: update RecursiveArrayTools compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LabelledArrays"
 uuid = "2ee39098-c373-598a-b85f-a56591580800"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.14.0"
+version = "1.14.1"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
@@ -9,9 +9,9 @@ ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 PreallocationTools = "d236fae5-4411-538c-8e31-a6e3d9e00b46"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
 ArrayInterface = "7"
@@ -19,7 +19,7 @@ ChainRulesCore = "1"
 ForwardDiff = "0.10.3"
 MacroTools = "0.5"
 PreallocationTools = "0.4"
-RecursiveArrayTools = "2"
+RecursiveArrayTools = "2,3"
 StaticArrays = "1.0"
 julia = "1.6"
 

--- a/test/diffeq.jl
+++ b/test/diffeq.jl
@@ -15,11 +15,11 @@ p = LorenzParameterVector(10.0, 28.0, 8 / 3)
 tspan = (0.0, 10.0)
 prob = ODEProblem(f, u0, tspan, p)
 sol = solve(prob, Rosenbrock23())
-@test sol.retcode == :Success
+@test sol.retcode == SciMLBase.ReturnCode.Success
 sol = solve(prob, Tsit5())
 @test prob.u0 === sol.u[1] === u0
 @test prob.p === p
-@test sol[10].x > 0
+@test sol[:, 10].x > 0
 
 function iip_f(du, u, p, t)
     du.x = p.σ * (u.y - u.x)
@@ -39,4 +39,4 @@ sol = solve(prob, Rosenbrock23())
 sol = solve(prob, Tsit5())
 @test typeof(prob.u0) == eltype(sol.u) == typeof(u0)
 @test prob.p === p
-@test sol[10].x > 0
+@test sol[:, 10].x > 0

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -18,7 +18,7 @@ using LabelledArrays, Test, InteractiveUtils
 
     z = LabelledArrays.LArray{Float64, 1, Vector{Float64}, (x = 1:4, y = 5:8)}(undef, 8)
     @test length(z) == 8
-    @test size(LabelledArrays.ArrayInterfaceCore.undefmatrix(z)) == (8, 8)
+    @test size(LabelledArrays.ArrayInterface.undefmatrix(z)) == (8, 8)
 
     for (i, s) in enumerate(syms)
         @show i, s


### PR DESCRIPTION
Tests won't pass in CI because of a circular dependency with OrdinaryDiffEq. To test, remove it from Project.toml and comment out the diffeq tests.