### PR TITLE
Remove erroneous `LVector` docstring and point user to the alternative that works.

### DIFF
--- a/src/larray.jl
+++ b/src/larray.jl
@@ -271,11 +271,11 @@ A = @LVector Float64 (:a, :b, :c, :d)
 A .= rand(4)
 ```
 
-On the other hand, users can also initialize the vector and set its values at the
-same time:
+To initialize the vector and set its values at the
+same time, used [`@LArray`](@ref) instead:
 
 ```julia
-b = @LVector [1, 2, 3] (:a, :b, :c)
+b = @LArray [1, 2, 3] (:a, :b, :c)
 ```
 """
 macro LVector(type, syms)

--- a/src/larray.jl
+++ b/src/larray.jl
@@ -272,7 +272,7 @@ A .= rand(4)
 ```
 
 To initialize the vector and set its values at the
-same time, used [`@LArray`](@ref) instead:
+same time, use [`@LArray`](@ref) instead:
 
 ```julia
 b = @LArray [1, 2, 3] (:a, :b, :c)

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -78,6 +78,9 @@ using LabelledArrays, Test, InteractiveUtils
     @test vcat(x, y) == [1, 2, 3, 4, 5, 6]
 
     @test_throws ErrorException x.z
+
+    # Ref #93, #154
+    @test_broken  @LVector [1, 2, 3] (:a, :b, :c)
 end
 
 @testset "Alternate array backends" begin


### PR DESCRIPTION
Closes #93

## Checklist

- [x] Appropriate tests were added
- [x] Any code changes were done in a way that does not break public API
- [x] All documentation related to code changes were updated
- [x] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [x] Any new documentation only uses public API
  
## Additional context

Add any other context about the problem here.
