### PR TITLE
ci: explicitly specify token for codecov

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,3 +41,5 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true


### PR DESCRIPTION
Explicitly specify the codecov token to be used (i.e., `CODECOV_TOKEN`), given that the latest v4 release of the codecov action requires it to be able to generate coverage reports. Additionally, fail CI if coverage reporting fails, since coverage is an important enough metric for us to ensure that it's tracked consistently.
