### PR TITLE
Fix typo in comment: 'errror' -> 'error'

### DIFF
--- a/src/larray.jl
+++ b/src/larray.jl
@@ -286,7 +286,7 @@ macro LVector(type, syms)
     end
 end
 
-#the following gives errror: TypeError: in <:, expected Type, got TypeVar
+#the following gives error: TypeError: in <:, expected Type, got TypeVar
 #symbols(::LArray{T,N,D<:AbstractArray{T,N},Syms}) where {T,N,D,Syms} = Syms
 
 """


### PR DESCRIPTION
## Summary
- Fix typo in src/larray.jl:289: 'errror' -> 'error'

## Context
The CI health check revealed that the Spell Check workflow was failing due to this typo in a comment. This PR fixes it.

## Test Plan
- [x] Local tests pass (`Pkg.test()` completed successfully)
- [ ] CI spell check should now pass

cc @ChrisRackauckas

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)