### PR TITLE
Fix RecursiveArrayTools compat lower bound for alldeps CI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ ChainRulesCore = "1"
 ForwardDiff = "0.10.3, 1"
 MacroTools = "0.5"
 PreallocationTools = "0.4"
-RecursiveArrayTools = "3"
+RecursiveArrayTools = "3.1"
 StaticArrays = "1.0"
 julia = "1.10"
 


### PR DESCRIPTION
## Summary
- Update RecursiveArrayTools compat from `"3"` to `"3.1"`

## Context
The alldeps CI job (Downgrade workflow) was failing because RecursiveArrayTools 3.0.0 has dependency resolution conflicts with other packages. When `julia-actions/julia-downgrade-compat@v2` with `mode: alldeps` tries to use RecursiveArrayTools 3.0.0, it fails with:

```
ERROR: LoadError: Unsatisfiable requirements detected for package RecursiveArrayTools
 RecursiveArrayTools [731186ca] log:
 ├─possible versions are: 0.16.0-3.42.1 or uninstalled
 ├─restricted to versions 3 by project, leaving only versions: 3.1.0-3.42.1
 └─restricted to versions 3.0.0 by an explicit requirement — no versions left
```

This PR updates the compat lower bound to `3.1` to exclude the problematic 3.0.0 version.

## Test Plan
- [x] Local tests pass (`Pkg.test()` completed successfully)
- [ ] CI alldeps test should now pass

cc @ChrisRackauckas

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)