### PR TITLE
Bump version to 1.17.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LabelledArrays"
 uuid = "2ee39098-c373-598a-b85f-a56591580800"
 authors = ["Chris Rackauckas <accounts@chrisrackauckas.com>"]
-version = "1.16.1"
+version = "1.17.0"
 
 [deps]
 ArrayInterface = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"


### PR DESCRIPTION
## Version Bump

Bumping version from 1.16.1 to 1.17.0 to prepare for release.

### Changes since v1.16.1 (16 commits)

**Compat changes:**
- Fix RecursiveArrayTools compat lower bound (3 -> 3.1) (#177)

**Bug fixes:**
- Fix typo in comment: 'errror' -> 'error' (#176)

**CI/Infrastructure improvements:**
- Add Downgrade CI workflow (#169)
- Add .typos.toml configuration + SpellCheck.yml workflow (#167)
- Migrate from CompatHelper to Dependabot for Julia ecosystem support (#174)
- Remove Invalidations.yml GitHub action workflow
- Fix dependabot updating typos every minor (#171)
- Fix spelling: additonal -> additional (#168)

### Registration Command

After merging, register with:

@JuliaRegistrator register

cc @ChrisRackauckas

🤖 Generated with [Claude Code](https://claude.com/claude-code)