### PR TITLE
Switch from JuliaFormatter to Runic.jl for code formatting

### DIFF
--- a/.JuliaFormatter.toml
+++ b/.JuliaFormatter.toml
@@ -1,3 +1,0 @@
-style = "sciml"
-format_markdown = true
-format_docstrings = true

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -1,13 +1,19 @@
-name: "Format Check"
+name: format-check
 
 on:
   push:
     branches:
       - 'master'
+      - 'main'
+      - 'release-'
     tags: '*'
   pull_request:
 
 jobs:
-  format-check:
-    name: "Format Check"
-    uses: "SciML/.github/.github/workflows/format-check.yml@v1"
+  runic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: fredrikekre/runic-action@v1
+        with:
+          version: '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,13 +5,19 @@ cp("./docs/Project.toml", "./docs/src/assets/Project.toml", force = true)
 
 include("pages.jl")
 
-makedocs(sitename = "LabelledArrays.jl",
+makedocs(
+    sitename = "LabelledArrays.jl",
     authors = "Chris Rackauckas",
     modules = [LabelledArrays],
     clean = true, doctest = false, linkcheck = true,
-    format = Documenter.HTML(assets = ["assets/favicon.ico"],
-        canonical = "https://docs.sciml.ai/LabelledArrays/stable/"),
-    pages = pages)
+    format = Documenter.HTML(
+        assets = ["assets/favicon.ico"],
+        canonical = "https://docs.sciml.ai/LabelledArrays/stable/"
+    ),
+    pages = pages
+)
 
-deploydocs(repo = "github.com/SciML/LabelledArrays.jl.git";
-    push_preview = true)
+deploydocs(
+    repo = "github.com/SciML/LabelledArrays.jl.git";
+    push_preview = true
+)

--- a/docs/pages.jl
+++ b/docs/pages.jl
@@ -6,5 +6,5 @@ pages = [
     "SLArrays" => "SLArrays.md",
     "LArrays" => "LArrays.md",
     "Relation to NamedTuples" => "NamedTuples_relation.md",
-    "Note: Labelled Slices" => "Note_labelled_slices.md"
+    "Note: Labelled Slices" => "Note_labelled_slices.md",
 ]

--- a/src/diffeqarray.jl
+++ b/src/diffeqarray.jl
@@ -1,7 +1,9 @@
 for LArrayType in [LArray, SLArray]
-    @eval function RecursiveArrayTools.DiffEqArray(vec::AbstractVector{<:$LArrayType},
+    @eval function RecursiveArrayTools.DiffEqArray(
+            vec::AbstractVector{<:$LArrayType},
             ts::AbstractVector,
-            p = nothing)
-        RecursiveArrayTools.DiffEqArray(vec, ts, p; variables = collect(symbols(vec[1])))
+            p = nothing
+        )
+        return RecursiveArrayTools.DiffEqArray(vec, ts, p; variables = collect(symbols(vec[1])))
     end
 end

--- a/src/slarray.jl
+++ b/src/slarray.jl
@@ -2,25 +2,25 @@ struct SLArray{S, T, N, L, Syms} <: StaticArray{S, T, N}
     __x::SArray{S, T, N, L}
     #SLArray{Syms}(__x::StaticArray{S,T,N}) where {S,N,Syms,T} = new{S,N,Syms,T}(__x)
     function SLArray{S, T, N, Syms}(__x::SArray) where {S, T, N, Syms}
-        new{S, T, N, length(__x), Syms}(convert.(T, __x))
+        return new{S, T, N, length(__x), Syms}(convert.(T, __x))
     end
     function SLArray{S, Syms}(__x::SArray{S, T, N, L}) where {S, T, N, L, Syms}
-        new{S, T, N, L, Syms}(__x)
+        return new{S, T, N, L, Syms}(__x)
     end
     function SLArray{S, T, Syms}(__x::SArray{S, T, N, L}) where {S, T, N, L, Syms}
-        new{S, T, N, L, Syms}(__x)
+        return new{S, T, N, L, Syms}(__x)
     end
     function SLArray{S, Syms}(x::Tuple) where {S, Syms}
         __x = SArray{S}(x)
-        SLArray{S, Syms}(__x)
+        return SLArray{S, Syms}(__x)
     end
     function SLArray{S, T, Syms}(x::Tuple) where {S, T, Syms}
         __x = SArray{S, T}(x)
-        SLArray{S, T, Syms}(__x)
+        return SLArray{S, T, Syms}(__x)
     end
     function SLArray{S, T, N, L, Syms}(x::Tuple) where {S, T, N, L, Syms}
         __x = SArray{S, T, N, L}(x)
-        new{S, T, N, L, Syms}(__x)
+        return new{S, T, N, L, Syms}(__x)
     end
 end
 
@@ -28,19 +28,23 @@ end
 # NamedTuple compatibility
 #####################################
 ## SLArray to named tuple
-function Base.convert(::Type{NamedTuple},
-        x::SLArray{S, T, N, L, Syms}) where {S, T, N, L, Syms}
+function Base.convert(
+        ::Type{NamedTuple},
+        x::SLArray{S, T, N, L, Syms}
+    ) where {S, T, N, L, Syms}
     tup = NTuple{length(Syms), T}(x.__x)
-    NamedTuple{Syms, typeof(tup)}(tup)
+    return NamedTuple{Syms, typeof(tup)}(tup)
 end
 Base.keys(x::SLArray{S, T, N, L, Syms}) where {S, T, N, L, Syms} = Syms
 
-function StaticArrays.similar_type(::Type{SLArray{S, T, N, L, Syms}}, T2,
-        ::Size{S}) where {S, T, N, L, Syms}
-    SLArray{S, T2, N, L, Syms}
+function StaticArrays.similar_type(
+        ::Type{SLArray{S, T, N, L, Syms}}, T2,
+        ::Size{S}
+    ) where {S, T, N, L, Syms}
+    return SLArray{S, T2, N, L, Syms}
 end
 function RecursiveArrayTools.recursive_unitless_eltype(a::Type{T}) where {T <: SLArray}
-    StaticArrays.similar_type(a, recursive_unitless_eltype(eltype(a)))
+    return StaticArrays.similar_type(a, recursive_unitless_eltype(eltype(a)))
 end
 
 ## Named tuple to SLArray
@@ -96,7 +100,7 @@ SLArray{Tuple{2, 2}}((a = 1, b = 2, c = 3, d = 4))
 """
 function SLArray{Size}(tup::NamedTuple{Syms, Tup}) where {Size, Syms, Tup}
     __x = Tup(tup) # drop symbols
-    SLArray{Size, Syms}(__x)
+    return SLArray{Size, Syms}(__x)
 end
 SLArray{Size}(; kwargs...) where {Size} = SLArray{Size}(values(kwargs))
 
@@ -143,11 +147,11 @@ SLVector(; kwargs...) = SLVector(values(kwargs))
 ## pairs iterator
 function Base.pairs(x::SLArray{S, T, N, L, Syms}) where {S, T, N, L, Syms}
     # (label => getproperty(x, label) for label in Syms) # not type stable?
-    (Syms[i] => x[i] for i in 1:length(Syms))
+    return (Syms[i] => x[i] for i in 1:length(Syms))
 end
 
 function Base.iterate(x::SLArray, args...)
-    iterate(convert(NamedTuple, x), args...)
+    return iterate(convert(NamedTuple, x), args...)
 end
 
 #####################################
@@ -156,21 +160,27 @@ end
 Base.@propagate_inbounds Base.getindex(x::SLArray, i::Int) = getfield(x, :__x)[i]
 @inline Base.Tuple(x::SLArray) = Tuple(x.__x)
 
-function StaticArrays.similar_type(::Type{SLArray{S, T, N, L, Syms}}, ::Type{NewElType},
-        ::Size{NewSize}) where {S, T, N, L, Syms, NewElType,
-        NewSize}
+function StaticArrays.similar_type(
+        ::Type{SLArray{S, T, N, L, Syms}}, ::Type{NewElType},
+        ::Size{NewSize}
+    ) where {
+        S, T, N, L, Syms, NewElType,
+        NewSize,
+    }
     n = prod(NewSize)
-    if n == L
+    return if n == L
         SLArray{Tuple{NewSize...}, NewElType, length(NewSize), L, Syms}
     else
         SArray{Tuple{NewSize...}, NewElType, length(NewSize), n}
     end
 end
 
-function Base.similar(::Type{SLArray{S, T, N, L, Syms}}, ::Type{NewElType},
-        ::Size{NewSize}) where {S, T, N, L, Syms, NewElType, NewSize}
+function Base.similar(
+        ::Type{SLArray{S, T, N, L, Syms}}, ::Type{NewElType},
+        ::Size{NewSize}
+    ) where {S, T, N, L, Syms, NewElType, NewSize}
     n = prod(NewSize)
-    if n == L
+    return if n == L
         tmp = Array{NewElType}(undef, NewSize)
         LArray{NewElType, length(NewSize), typeof(tmp), Syms}(tmp)
     else
@@ -181,31 +191,36 @@ end
 @inline Base.propertynames(::SLArray{S, T, N, L, Syms}) where {S, T, N, L, Syms} = Syms
 @inline symnames(::Type{SLArray{S, T, N, L, Syms}}) where {S, T, N, L, Syms} = Syms
 Base.@propagate_inbounds function Base.getproperty(x::SLArray, s::Symbol)
-    s == :__x || s == :data ? getfield(x, :__x) : getindex(x, Val(s))
+    return s == :__x || s == :data ? getfield(x, :__x) : getindex(x, Val(s))
 end
 Base.@propagate_inbounds function Base.getindex(x::SLArray, s::Symbol)
     return getindex(x, Val(s))
 end
 Base.@propagate_inbounds Base.getindex(x::SLArray, s::Val) = __getindex(x, s)
-Base.@propagate_inbounds function Base.getindex(x::SLArray,
-        inds::AbstractArray{I, 1}) where {
+Base.@propagate_inbounds function Base.getindex(
+        x::SLArray,
+        inds::AbstractArray{I, 1}
+    ) where {
         I <:
-        Integer}
-    getindex(x.__x, inds)
+        Integer,
+    }
+    return getindex(x.__x, inds)
 end
 Base.@propagate_inbounds function Base.getindex(x::SLArray, inds::StaticVector{<:Any, Int})
-    getindex(x.__x, inds)
+    return getindex(x.__x, inds)
 end
 
 # Note: This could in the future return an SLArray with the right names
 Base.@propagate_inbounds function Base.getindex(x::SLArray, s::AbstractArray{Symbol, 1})
-    [getindex(x, si) for si in s]
+    return [getindex(x, si) for si in s]
 end
 
-function Base.vcat(x1::SLArray{S1, T, 1, L1, Syms1},
-        x2::SLArray{S2, T, 1, L2, Syms2}) where {S1, S2, T, L1, L2, Syms1, Syms2}
+function Base.vcat(
+        x1::SLArray{S1, T, 1, L1, Syms1},
+        x2::SLArray{S2, T, 1, L2, Syms2}
+    ) where {S1, S2, T, L1, L2, Syms1, Syms2}
     __x = vcat(x1.__x, x2.__x)
-    SLArray{StaticArrays.size_tuple(Size(__x)), (Syms1..., Syms2...)}(__x)
+    return SLArray{StaticArrays.size_tuple(Size(__x)), (Syms1..., Syms2...)}(__x)
 end
 
 """
@@ -259,7 +274,7 @@ julia> z.a
 macro SLArray(dims, syms)
     dims isa Expr && (dims = dims.args)
     syms = esc(syms)
-    quote
+    return quote
         SLArray{Tuple{$dims...}, $syms}
     end
 end
@@ -267,7 +282,7 @@ end
 macro SLArray(T, dims, syms)
     dims isa Expr && (dims = dims.args)
     syms = esc(syms)
-    quote
+    return quote
         SLArray{Tuple{$dims...}, $T, $(length(dims)), $(prod(dims)), $syms}
     end
 end
@@ -293,7 +308,7 @@ x.c == x[3]
 """
 macro SLVector(syms)
     syms = esc(syms)
-    quote
+    return quote
         n = $syms isa NamedTuple ? maximum(map(maximum, $syms)) : length($syms)
         SLArray{Tuple{n}, $syms}
     end
@@ -302,7 +317,7 @@ end
 macro SLVector(T, syms)
     T = esc(T)
     syms = esc(syms)
-    quote
+    return quote
         n = $syms isa NamedTuple ? maximum(map(maximum, $syms)) : length($syms)
         SLArray{Tuple{n}, $T, 1, n, $syms}
     end
@@ -327,15 +342,19 @@ julia> symbols(z)
 ```
 """
 function symbols(::SLArray{S, T, N, L, Syms}) where {S, T, N, L, Syms}
-    Syms isa NamedTuple ? keys(Syms) : Syms
+    return Syms isa NamedTuple ? keys(Syms) : Syms
 end
 
 function Base.:\(A::StaticArrays.LU, b::SLArray{S, T, N, L, Syms}) where {S, T, N, L, Syms}
-    SLArray{S, T, N, L, Syms}((A \ b.__x).data)
+    return SLArray{S, T, N, L, Syms}((A \ b.__x).data)
 end
 
-function Base.reshape(x::SLArray{S, T, N, L, Syms},
-        ax::Tuple{SOneTo, Vararg{SOneTo}}) where {S <: Tuple, T, N, L, Syms,
-        SOneTo <: SOneTo}
-    SLArray{S, T, N, L, Syms}(reshape(x.__x, ax))
+function Base.reshape(
+        x::SLArray{S, T, N, L, Syms},
+        ax::Tuple{SOneTo, Vararg{SOneTo}}
+    ) where {
+        S <: Tuple, T, N, L, Syms,
+        SOneTo <: SOneTo,
+    }
+    return SLArray{S, T, N, L, Syms}(reshape(x.__x, ax))
 end

--- a/test/alloc_tests.jl
+++ b/test/alloc_tests.jl
@@ -10,14 +10,16 @@ using StaticArrays
 
         # Property access should be allocation-free
         @check_allocs function test_slarray_property_a(
-                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)})
+                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}
+            )
             arr.a
         end
         @test test_slarray_property_a(sv) == 1.0
 
         # Integer indexing should be allocation-free
         @check_allocs function test_slarray_getindex_int(
-                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}, i::Int)
+                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}, i::Int
+            )
             arr[i]
         end
         @test test_slarray_getindex_int(sv, 1) == 1.0
@@ -26,7 +28,8 @@ using StaticArrays
 
         # Val-based symbol access should be allocation-free
         @check_allocs function test_slarray_getindex_val(
-                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)})
+                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}
+            )
             getindex(arr, Val(:a))
         end
         @test test_slarray_getindex_val(sv) == 1.0
@@ -35,7 +38,8 @@ using StaticArrays
         sv2 = SLVector(a = 4.0, b = 5.0, c = 6.0)
         @check_allocs function test_slarray_broadcast_add(
                 arr1::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)},
-                arr2::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)})
+                arr2::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}
+            )
             arr1 .+ arr2
         end
         result = test_slarray_broadcast_add(sv, sv2)
@@ -45,7 +49,8 @@ using StaticArrays
 
         # Scalar broadcasting should be allocation-free
         @check_allocs function test_slarray_broadcast_scalar(
-                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}, x::Float64)
+                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}, x::Float64
+            )
             arr .* x
         end
         result = test_slarray_broadcast_scalar(sv, 2.0)
@@ -55,7 +60,8 @@ using StaticArrays
 
         # NamedTuple conversion should be allocation-free
         @check_allocs function test_slarray_namedtuple(
-                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)})
+                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}
+            )
             convert(NamedTuple, arr)
         end
         nt = test_slarray_namedtuple(sv)
@@ -63,21 +69,24 @@ using StaticArrays
 
         # copy should be allocation-free for SLArray
         @check_allocs function test_slarray_copy(
-                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)})
+                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}
+            )
             copy(arr)
         end
         @test test_slarray_copy(sv) == sv
 
         # symbols function should be allocation-free
         @check_allocs function test_slarray_symbols(
-                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)})
+                arr::SLArray{Tuple{3}, Float64, 1, 3, (:a, :b, :c)}
+            )
             symbols(arr)
         end
         @test test_slarray_symbols(sv) == (:a, :b, :c)
 
         # 2D SLArray property access should be allocation-free
         @check_allocs function test_slarray_2d_property(
-                arr::SLArray{Tuple{2, 2}, Float64, 2, 4, (:a, :b, :c, :d)})
+                arr::SLArray{Tuple{2, 2}, Float64, 2, 4, (:a, :b, :c, :d)}
+            )
             arr.c
         end
         @test test_slarray_2d_property(sm) == 3.0
@@ -90,14 +99,16 @@ using StaticArrays
 
         # Property access should be allocation-free
         @check_allocs function test_larray_property_a(
-                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)})
+                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}
+            )
             arr.a
         end
         @test test_larray_property_a(lv) == 1.0
 
         # Integer indexing should be allocation-free
         @check_allocs function test_larray_getindex_int(
-                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}, i::Int)
+                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}, i::Int
+            )
             arr[i]
         end
         @test test_larray_getindex_int(lv, 1) == 1.0
@@ -106,14 +117,16 @@ using StaticArrays
 
         # Val-based symbol access should be allocation-free
         @check_allocs function test_larray_getindex_val(
-                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)})
+                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}
+            )
             getindex(arr, Val(:a))
         end
         @test test_larray_getindex_val(lv) == 1.0
 
         # Property write should be allocation-free
         @check_allocs function test_larray_setproperty(
-                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}, val::Float64)
+                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}, val::Float64
+            )
             arr.a = val
         end
         test_larray_setproperty(lv, 10.0)
@@ -122,7 +135,8 @@ using StaticArrays
 
         # Integer setindex should be allocation-free
         @check_allocs function test_larray_setindex_int(
-                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}, val::Float64, i::Int)
+                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}, val::Float64, i::Int
+            )
             arr[i] = val
         end
         test_larray_setindex_int(lv, 20.0, 1)
@@ -137,7 +151,8 @@ using StaticArrays
         lv_dest2 = LVector(a = 0.0, b = 0.0, c = 0.0)
         @check_allocs function test_larray_copyto!(
                 dest::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)},
-                src::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)})
+                src::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}
+            )
             copyto!(dest, src)
         end
         test_larray_copyto!(lv_dest2, lv)
@@ -145,7 +160,8 @@ using StaticArrays
 
         # NamedTuple conversion should be allocation-free
         @check_allocs function test_larray_namedtuple(
-                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)})
+                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}
+            )
             convert(NamedTuple, arr)
         end
         nt = test_larray_namedtuple(lv)
@@ -153,21 +169,24 @@ using StaticArrays
 
         # symbols function should be allocation-free
         @check_allocs function test_larray_symbols(
-                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)})
+                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}
+            )
             symbols(arr)
         end
         @test test_larray_symbols(lv) == (:a, :b, :c)
 
         # 2D LArray property access should be allocation-free
         @check_allocs function test_larray_2d_property(
-                arr::LArray{Float64, 2, Matrix{Float64}, (:a, :b, :c, :d)})
+                arr::LArray{Float64, 2, Matrix{Float64}, (:a, :b, :c, :d)}
+            )
             arr.c
         end
         @test test_larray_2d_property(lm) == 3.0
 
         # size should be allocation-free
         @check_allocs function test_larray_size(
-                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)})
+                arr::LArray{Float64, 1, Vector{Float64}, (:a, :b, :c)}
+            )
             size(arr)
         end
         @test test_larray_size(lv) == (3,)
@@ -179,7 +198,8 @@ using StaticArrays
 
         # Note: Range-based property access returns a view, which should be allocation-free
         @check_allocs function test_range_property(
-                arr::LArray{Float64, 1, Vector{Float64}, (x = 1:3, y = 4:6)})
+                arr::LArray{Float64, 1, Vector{Float64}, (x = 1:3, y = 4:6)}
+            )
             arr.x
         end
         v = test_range_property(lv_range)

--- a/test/diffeq.jl
+++ b/test/diffeq.jl
@@ -7,7 +7,7 @@ function f(u, p, t)
     x = p.σ * (u.y - u.x)
     y = u.x * (p.ρ - u.z) - u.y
     z = u.x * u.y - p.β * u.z
-    LorenzVector(x, y, z)
+    return LorenzVector(x, y, z)
 end
 
 u0 = LorenzVector(1.0, 0.0, 0.0)
@@ -24,7 +24,7 @@ sol = solve(prob, Tsit5())
 function iip_f(du, u, p, t)
     du.x = p.σ * (u.y - u.x)
     du.y = u.x * (p.ρ - u.z) - u.y
-    du.z = u.x * u.y - p.β * u.z
+    return du.z = u.x * u.y - p.β * u.z
 end
 
 u0 = @LArray [1.0, 0.0, 0.0] (:x, :y, :z)

--- a/test/larrays.jl
+++ b/test/larrays.jl
@@ -70,7 +70,7 @@ using LabelledArrays, Test, InteractiveUtils
     @test setindex!(x, 2, :a) == LVector(a = 2, b = 2, c = 3)
     @test setindex!(x, 2, :a) == LVector(a = 2, b = 2, c = 3)
     @test setindex!(LArray((2, 2), a = 1, b = 2, c = 3, d = 4), 1, :b) ==
-          LArray((2, 2), a = 1, b = 1, c = 3, d = 4)
+        LArray((2, 2), a = 1, b = 1, c = 3, d = 4)
 
     x = @LArray [1, 2, 3] (:a, :b, :c)
     y = @LArray [4, 5, 6] (:d, :e, :f)

--- a/test/slarrays.jl
+++ b/test/slarrays.jl
@@ -24,15 +24,15 @@ using Test, InteractiveUtils
 
     @test @inferred(similar_type(b, Float64)) === ABC_fl
     @test @inferred(similar_type(b, Float64, Size(1, 3))) ===
-          @SLArray Float64 (1, 3) (:a, :b, :c)
+        @SLArray Float64 (1, 3) (:a, :b, :c)
     @test @inferred(similar_type(b, Float64, Size(3, 3))) ===
-          SArray{Tuple{3, 3}, Float64, 2, 9}
+        SArray{Tuple{3, 3}, Float64, 2, 9}
 
     @test typeof(@inferred(similar(b))) === LArray{Int, 1, Array{Int64, 1}, (:a, :b, :c)}
     @test typeof(@inferred(similar(b, Float64))) ===
-          LArray{Float64, 1, Array{Float64, 1}, (:a, :b, :c)}
+        LArray{Float64, 1, Array{Float64, 1}, (:a, :b, :c)}
     @test typeof(@inferred(similar(b, Size(1, 3)))) ===
-          LArray{Int, 2, Array{Int64, 2}, (:a, :b, :c)}
+        LArray{Int, 2, Array{Int64, 2}, (:a, :b, :c)}
     @test typeof(@inferred(similar(b, Size(3, 3)))) === MArray{Tuple{3, 3}, Int, 2, 9}
 
     @test @inferred(copy(b)) === ABC_int(Tuple(b))


### PR DESCRIPTION
## Summary
- Updated CI workflow to use `fredrikekre/runic-action@v1` instead of JuliaFormatter
- Removed `.JuliaFormatter.toml` configuration file
- Reformatted all source files with Runic.jl

## Changes
This PR migrates the code formatting from JuliaFormatter with SciMLStyle to Runic.jl. Runic.jl is an opinionated formatter (similar to Go's gofmt) that requires no configuration.

Key differences from JuliaFormatter:
- Explicit `return` statements are added where implicit
- Different indentation and alignment for continuation lines
- Consistent multiline formatting for function arguments

## Test plan
- [ ] CI format check passes with Runic.jl
- [ ] All existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)