### PR TITLE
Centralize CI on SciML reusable workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,6 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "crate-ci/typos"
-        update-types: ["version-update:semver-patch", "version-update:semver-minor"]
   - package-ecosystem: "julia"
     directories:
       - "/"

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -11,22 +11,11 @@ on:
     paths-ignore:
       - 'docs/**'
 jobs:
-  test:
+  downgrade:
     if: false  # Disabled: OrdinaryDiffEq minimum version requires StaticArrays 0.8-0.12, conflicts with StaticArrays >= 1.0 compat
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        downgrade_mode: ['alldeps']
-        julia-version: ['1.10']
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.julia-version }}
-      - uses: julia-actions/julia-downgrade-compat@v2
-        with:
-          skip: Pkg,TOML
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-        with:
-          ALLOW_RERESOLVE: false
+    name: "Downgrade"
+    uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
+    with:
+      julia-version: "1.10"
+      skip: "Pkg,TOML"
+    secrets: "inherit"

--- a/.github/workflows/FormatCheck.yml
+++ b/.github/workflows/FormatCheck.yml
@@ -11,12 +11,6 @@ on:
 
 jobs:
   runic:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: fredrikekre/runic-action@v1
-        with:
-          version: '1'
+    name: "Runic"
+    uses: "SciML/.github/.github/workflows/runic.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/SpellCheck.yml
+++ b/.github/workflows/SpellCheck.yml
@@ -4,10 +4,6 @@ on: [pull_request]
 
 jobs:
   typos-check:
-    name: Spell Check with Typos
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout Actions Repository
-        uses: actions/checkout@v6
-      - name: Check spelling
-        uses: crate-ci/typos@v1.18.0
+    name: "Spell Check with Typos"
+    uses: "SciML/.github/.github/workflows/spellcheck.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
Please ignore until reviewed by @ChrisRackauckas.

## What this does

Converts the remaining inline CI checks to the centralized `SciML/.github` reusable workflows, pinned at `@v1`, each with `secrets: "inherit"`.

### Converted (inline -> central caller)
- **Runic** (`FormatCheck.yml`): `fredrikekre/runic-action` inline -> `runic.yml@v1`.
- **SpellCheck** (`SpellCheck.yml`): `crate-ci/typos@v1.18.0` inline -> `spellcheck.yml@v1`.
- **Downgrade** (`Downgrade.yml`): inline downgrade job -> `downgrade.yml@v1`, preserving `if: false` (the workflow remains disabled per the existing StaticArrays-compat comment), `julia-version: "1.10"`, and `skip: "Pkg,TOML"`.

### Already central (left as-is, confirmed `secrets: "inherit"`)
- **Tests** (`Tests.yml`): already a `tests.yml@v1` caller with the `1`/`lts`/`pre` version matrix. The repo-specific `AllocCheck` job is a custom check not covered by the central callers and is left inline unchanged.
- **Documentation** (`Documentation.yml`): already a `documentation.yml@v1` caller.

### Cleanup
- Removed the `crate-ci/typos` ignore block from `dependabot.yml` (the `github-actions` weekly + `julia` daily blocks are preserved). No `CompatHelper.yml` present. `TagBot.yml` unchanged.

### Checks status
- **Typos**: ran `typos .` locally -> already clean, exit 0, 0 typos fixed. Existing `.typos.toml` is picked up by crate-ci/typos automatically.
- **Runic**: ran `Runic.main(["--inplace","."])` locally -> no changes (repo was already Runic-clean from the prior inline check).

### Note on branch protection
Check names change with this conversion (e.g. the Runic and SpellCheck job display names now come from the reusable workflows). Branch-protection required-check names may need updating accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)