### PR TITLE
ci: route CI through SciML/.github reusable workflows (@v1)

### DIFF
--- a/.github/workflows/Tests.yml
+++ b/.github/workflows/Tests.yml
@@ -33,15 +33,8 @@ jobs:
 
   alloccheck:
     name: "AllocCheck"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: '1'
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - name: Run AllocCheck tests
-        run: julia --project -e 'using Pkg; Pkg.test(; test_args=["nopre"])'
-        env:
-          GROUP: nopre
+    uses: "SciML/.github/.github/workflows/tests.yml@v1"
+    with:
+      julia-version: "1"
+      group: "nopre"
+    secrets: "inherit"


### PR DESCRIPTION
## Summary

Centralizes CI by routing the one remaining bespoke job through the SciML/.github reusable workflows (`@v1`). Most of this repo's CI was already centralized; only one bespoke job remained.

## Converted

| Workflow | Job | Change |
|----------|-----|--------|
| `Tests.yml` | `alloccheck` | Bespoke `runs-on`/`steps` job → caller of `SciML/.github/.github/workflows/tests.yml@v1` with `julia-version: "1"`, `group: "nopre"` |

The bespoke `alloccheck` job previously ran `julia --project -e 'using Pkg; Pkg.test(; test_args=["nopre"])'` with `env: GROUP: nopre`. `test/runtests.jl` dispatches the AllocCheck tests **solely** on `ENV["GROUP"] == "nopre"` (it never reads `ARGS`), so the `test_args` were a no-op. The reusable `tests.yml@v1` sets `env: GROUP: ${{ inputs.group }}`, so passing `group: "nopre"` runs exactly the same tests. The reusable additionally collects coverage by default, which only increases CI fidelity — no coverage is dropped.

## Left as-is (already reusable — untouched)

- `Tests.yml` (`tests` matrix job) — already `uses: SciML/.github/.github/workflows/tests.yml@v1`, with the `["1","lts","pre"]` version matrix preserved.
- `Documentation.yml` — already `uses: .../documentation.yml@v1`.
- `Downgrade.yml` — already `uses: .../downgrade.yml@v1` (its `if: false` gate is preserved untouched).
- `FormatCheck.yml` — already `uses: .../runic.yml@v1`.
- `SpellCheck.yml` — already `uses: .../spellcheck.yml@v1`.

## Left local (non-CI automation)

- `TagBot.yml` — release tagging automation; no reusable equivalent.

## NOTE on branch protection

Required-status-check names change to the reusable workflow's job names. The `alloccheck` job's status check name will change from the old bespoke job name to the reusable's `Tests` job naming. **Branch protection settings will need to be updated** to match the new required-status-check names.

---

Please ignore until reviewed by @ChrisRackauckas.