### PR TITLE
ci: add standard centralized workflows (auto-format, dependabot-automerge, docs-preview-cleanup)

### DIFF
--- a/.github/workflows/DependabotAutoMerge.yml
+++ b/.github/workflows/DependabotAutoMerge.yml
@@ -1,0 +1,9 @@
+name: "Dependabot Auto-merge"
+on: pull_request
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  automerge:
+    uses: "SciML/.github/.github/workflows/dependabot-automerge.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,10 @@
+name: "Doc Preview Cleanup"
+on:
+  pull_request:
+    types: [closed]
+permissions:
+  contents: write
+jobs:
+  cleanup:
+    uses: "SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1"
+    secrets: "inherit"

--- a/.github/workflows/RunicSuggestions.yml
+++ b/.github/workflows/RunicSuggestions.yml
@@ -1,0 +1,9 @@
+name: "Runic Suggestions"
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  runic-suggestions:
+    uses: "SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
This PR adds the standard SciML centralized CI caller workflows that were missing from this repo:

- **`RunicSuggestions.yml`** (auto-format suggestions) — uses `SciML/.github/.github/workflows/runic-suggestions-on-pr.yml@v1`. This repo's format check is Runic-based, so the matching suggestion workflow is Runic.
- **`DependabotAutoMerge.yml`** (dependabot auto-merge) — uses `SciML/.github/.github/workflows/dependabot-automerge.yml@v1`.
- **`DocPreviewCleanup.yml`** (docs preview cleanup) — uses `SciML/.github/.github/workflows/docs-preview-cleanup.yml@v1`. Added because this repo has a `docs/` Documenter site.

These are static caller files referencing the centralized reusable workflows in `SciML/.github`. No existing files, `Project.toml`, or source code were touched.

**Please ignore this PR until reviewed by @ChrisRackauckas.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
