### PR TITLE
Canonical CI cleanup: TagBot thin-caller + downgrade-caller cleanup

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -14,7 +14,4 @@ jobs:
   downgrade:
     name: "Downgrade"
     uses: "SciML/.github/.github/workflows/downgrade.yml@v1"
-    with:
-      julia-version: "1.10"
-      skip: "Pkg,TOML"
     secrets: "inherit"

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,15 +1,9 @@
-name: TagBot
+name: "TagBot"
 on:
   issue_comment:
-    types:
-      - created
+    types: [created]
   workflow_dispatch:
 jobs:
-  TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: JuliaRegistries/TagBot@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+  tagbot:
+    uses: "SciML/.github/.github/workflows/tagbot.yml@v1"
+    secrets: "inherit"


### PR DESCRIPTION
## Canonical CI cleanup

- **TagBot**: replaced the inlined `JuliaRegistries/TagBot` job (with hand-rolled permissions/steps) with the canonical thin caller `SciML/.github/.github/workflows/tagbot.yml@v1` (`secrets: inherit`). Not a monorepo (no registered `lib/` subpackages), so no `tagbot-subpackages` matrix.
- **Downgrade**: removed the `skip: "Pkg,TOML"` input (both are Julia stdlibs; the centralized `downgrade.yml@v1` now auto-populates the skip list with stdlibs ∪ in-repo sublibs ∪ caller package). Removed the explicit `julia-version: "1.10"` to take the central `lts` default (LTS is the minimum-supported floor; `[compat]` julia floors untouched).
- **Typos**: `.typos.toml` already present; no change.

Ignore until reviewed by @ChrisRackauckas.