### PR TITLE
Enable LabelledArrays rendered docs QA

### DIFF
--- a/test/qa/qa.jl
+++ b/test/qa/qa.jl
@@ -25,6 +25,7 @@ using SciMLTesting, LabelledArrays, Test
 # the LTS QA lane green; on 1.11+ they are genuinely public.
 run_qa(
     LabelledArrays;
+    api_docs_kwargs = (; rendered = true),
     aqua_kwargs = (;
         ambiguities = false,
         unbound_args = false,


### PR DESCRIPTION
Ignore this PR until reviewed by @ChrisRackauckas.

## Summary
- Enable SciMLTesting rendered public API docs QA for LabelledArrays.
- No source docstrings or rendered docs pages needed changes; the existing docs already render the exported API checked by SciMLTesting.

## Validation
- `git diff --check` passed.
- QA passed with `api_docs_kwargs = (; rendered = true)`: Quality Assurance 14/14.
- `include("docs/make.jl")` completed locally; Documenter only emitted the expected local deployment skip warning.
- `Pkg.test()` passed. Test summary included ChainRules 50/50, DiffEq 9/9, LArrays 72 pass / 4 pre-existing broken, RecursiveArrayTools 1/1, SLArrays 48/48.
- Runic v1.7.0 passed over `src`, `test`, and `docs`.
